### PR TITLE
Refactor base URL handling during fresh installation

### DIFF
--- a/application/views/install_view.php
+++ b/application/views/install_view.php
@@ -87,11 +87,11 @@
             </div>
         <?php endif; ?>
 
-        <?php echo form_open('install/setup'); ?>
+        <form method="post" action="<?php echo isset($form_action) ? htmlspecialchars($form_action, ENT_QUOTES, 'UTF-8') : ''; ?>">
 
             <div class="form-group">
                 <label for="base_url">Base URL Aplikasi</label>
-                <input type="text" name="base_url" id="base_url" value="<?php echo set_value('base_url', (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]" . preg_replace('@/index\.php$@' ,'', $_SERVER['SCRIPT_NAME']) . '/'); ?>" required>
+                <input type="text" name="base_url" id="base_url" value="<?php echo set_value('base_url', isset($suggested_base_url) ? htmlspecialchars($suggested_base_url, ENT_QUOTES, 'UTF-8') : ''); ?>" required>
                 <small>Contoh: http://localhost/nama_folder_aplikasi/</small>
             </div>
 


### PR DESCRIPTION
This commit improves how the base URL is handled during the initial installation process, especially when `config['base_url']` is initially empty.

Key changes:
- In `application/controllers/Install.php`:
    - Added `determine_current_url_base()` method to dynamically detect the current correct base URL from `$_SERVER` variables.
    - `index()` method now passes a dynamically determined `form_action` URL and `suggested_base_url` to the installation view.
    - `setup()` method now uses the `base_url` provided by the user in the form for updating the config file and for the final redirect, ensuring consistency.
    - If `setup()` re-renders the view due to an error, it also passes the correct `form_action` and `suggested_base_url`.
    - `dbforge` is now loaded sytu HANYA ketika diperlukan dalam method `setup_database_schema()`.
- In `application/views/install_view.php`:
    - Replaced `form_open()` CI helper with a standard HTML `<form>` tag.
    - The `action` attribute of the form is now set dynamically from the `$form_action` variable passed by the controller.
    - The default value for the `base_url` input field is now set from the `$suggested_base_url` variable, also passed by the controller.

These changes ensure that form submissions and redirects during installation use a base URL consistent with what the user is currently accessing, rather than relying on CodeIgniter's initial guess or a potentially empty config value.